### PR TITLE
Adding comments, adding new struct field, rewriting JunbiOK functions

### DIFF
--- a/handlers/anime.go
+++ b/handlers/anime.go
@@ -38,8 +38,9 @@ func clamp(v, l, h int64) int64 {
 
 func AnimeStatus(m *discordgo.MessageCreate, args []string) error {
 	//Message user with list of commands if no command is specified
-	if len(args) < 2 {
+	if len(args) < 1 {
 		chat.SendPrivateMessageTo(m.Author.ID, "Usage: !anime <add|drop|del|incr|decr|set|rename|get|list|start> <name> [<value>]")
+		return nil
 	}
 
 	//Open connection to Redis server

--- a/handlers/anime.go
+++ b/handlers/anime.go
@@ -246,10 +246,10 @@ func AnimeStatus(m *discordgo.MessageCreate, args []string) error {
 		{
 			//Builds list of existing anime
 			tplText := `Markdown
-			{{ pad .Len " " "Title" }} | Episode | Members | Last Updated
-			{{ pad .Len "-" "-----" }}-+---------+---------+-------------
-			{{ range .Animes }}{{ pad $.Len " " .Name }} | {{ with $x := printf "%d" .CurrentEpisode }}{{ pad 7 " " $x }}{{ end }} | {{with $x :=  len .Members | printf "%d" }}{{ pad 7 " " $x }}{{ end }} | {{ .LastModified.Format "Mon, January 02" }}
-			{{ end }}`
+{{ pad .Len " " "Title" }} | Episode | Members | Last Updated
+{{ pad .Len "-" "-----" }}-+---------+---------+-------------
+{{ range .Animes }}{{ pad $.Len " " .Name }} | {{ with $x := printf "%d" .CurrentEpisode }}{{ pad 7 " " $x }}{{ end }} | {{with $x :=  len .Members | printf "%d" }}{{ pad 7 " " $x }}{{ end }} | {{ .LastModified.Format "Mon, January 02" }}
+{{ end }}`
 
 			buff := bytes.NewBuffer(nil)
 

--- a/handlers/anime.go
+++ b/handlers/anime.go
@@ -285,14 +285,12 @@ func JunbiOK(m *discordgo.MessageCreate, args []string) error {
 	conn := Redis.Get()
 	defer conn.Close()
 
-	//Read values from the Redis database, creates key on per-chat basis
+	//Overwrites any existing value for junbiStatus
 	key := makeKey("junbistatus:%s", m.ChannelID)
 	res := junbiStatus{true, args}
+	serialize(conn, key, &res)
 
 	chat.SendMessageToChannel(m.ChannelID, fmt.Sprintf("Junbi OK? Type !rdy to confirm!"))
-
-	//Write the modified value to the Redis database
-	serialize(conn, key, &res)
 	return nil
 }
 
@@ -301,7 +299,7 @@ func JunbiRdy(m *discordgo.MessageCreate, args []string) error {
 	conn := Redis.Get()
 	defer conn.Close()
 
-	//Read values from the Redis database, creates key on per-chat basis
+	//Read values from the Redis database
 	key := makeKey("junbistatus:%s", m.ChannelID)
 	res := junbiStatus{}
 	deserialize(conn, key, &res)

--- a/handlers/anime.go
+++ b/handlers/anime.go
@@ -223,8 +223,6 @@ func JunbiOK(m *discordgo.MessageCreate, args []string) error {
 }
 
 func JunbiRdy(m *discordgo.MessageCreate, args []string) error {
-	var err error
-
 	if junbiInitiated != true {
 		chat.SendMessageToChannel(m.ChannelID, fmt.Sprintf("Countdown has not been initiated! Type !junbiok to begin!"))
 		return nil

--- a/handlers/anime.go
+++ b/handlers/anime.go
@@ -316,12 +316,11 @@ func JunbiRdy(m *discordgo.MessageCreate, args []string) error {
 			message += fmt.Sprintf("%s\t", n)
 		}
 		chat.SendMessageToChannel(m.ChannelID, message)
-		return nil
+	} else {
+		//Resets Initialized flag to false, starts countdown
+		res.Initialized = false
+		Countdown(m, []string{"3"})
 	}
-
-	//Resets Initialized flag to false, starts countdown
-	res.Initialized = false
-	Countdown(m, []string{"3"})
 
 	//Write the modified value to the Redis database
 	serialize(conn, key, &res)

--- a/handlers/anime.go
+++ b/handlers/anime.go
@@ -70,7 +70,6 @@ func AnimeStatus(m *discordgo.MessageCreate, args []string) error {
 			delete(res, args[1])
 			break
 		}
-
 	case "set":
 		{
 			if len(args) != 3 {
@@ -97,7 +96,6 @@ func AnimeStatus(m *discordgo.MessageCreate, args []string) error {
 			chat.SendMessageToChannel(m.ChannelID, fmt.Sprintf("%s - %d (%s)", v.Name, v.CurrentEpisode, v.LastModified.Format("Mon, January 02")))
 			break
 		}
-
 	case "get":
 		{
 			if len(args) != 2 {
@@ -112,9 +110,7 @@ func AnimeStatus(m *discordgo.MessageCreate, args []string) error {
 			}
 			chat.SendMessageToChannel(m.ChannelID, fmt.Sprintf("%s - %d (%s)", v.Name, v.CurrentEpisode, v.LastModified.Format("Mon, January 02")))
 		}
-
-	case "incr":
-	case "decr":
+	case "incr", "decr":
 		{
 			if len(args) != 2 {
 				chat.SendPrivateMessageTo(m.Author.ID, fmt.Sprintf("Usage: !anime %s <name>", args[0]))
@@ -141,7 +137,6 @@ func AnimeStatus(m *discordgo.MessageCreate, args []string) error {
 				res[args[1]] = v
 				chat.SendMessageToChannel(m.ChannelID, fmt.Sprintf("%s - %d (%s)", v.Name, v.CurrentEpisode, v.LastModified.Format("Mon, January 02")))
 			}
-			break
 		}
 	case "list":
 		{

--- a/handlers/anime.go
+++ b/handlers/anime.go
@@ -244,11 +244,12 @@ func AnimeStatus(m *discordgo.MessageCreate, args []string) error {
 		}
 	case "list":
 		{
+			//Builds list of existing anime
 			tplText := `Markdown
-{{ pad .Len " " "Title" }} | Episode | Last Updated
-{{ pad .Len "-" "-----" }}-+---------+-------------
-{{ range .Animes }}{{ pad $.Len " " .Name }} | {{ with $x := printf "%d" .CurrentEpisode }}{{ pad 7 " " $x }}{{ end }} | {{ .LastModified.Format "Mon, January 02" }}
-{{ end }}`
+			{{ pad .Len " " "Title" }} | Episode | Members | Last Updated
+			{{ pad .Len "-" "-----" }}-+---------+---------+-------------
+			{{ range .Animes }}{{ pad $.Len " " .Name }} | {{ with $x := printf "%d" .CurrentEpisode }}{{ pad 7 " " $x }}{{ end }} | {{with $x :=  len .Members | printf "%d" }}{{ pad 7 " " $x }}{{ end }} | {{ .LastModified.Format "Mon, January 02" }}
+			{{ end }}`
 
 			buff := bytes.NewBuffer(nil)
 
@@ -257,7 +258,6 @@ func AnimeStatus(m *discordgo.MessageCreate, args []string) error {
 					if len(val) < amount {
 						return strings.Repeat(spacer, amount-len(val)) + val
 					}
-
 					return val
 				},
 			}).Parse(tplText)
@@ -282,19 +282,9 @@ func AnimeStatus(m *discordgo.MessageCreate, args []string) error {
 				log.Print(err)
 			}
 
+			//Outputs list to chat in codeblock form
 			chat.SendMessageToChannel(m.ChannelID, "```"+buff.String()+"```")
 		}
-		//	case "list":
-		//		{
-		//Builds list of existing anime
-		//			message := "\tName\tLast Ep\tMembers\tLast Watched\n"
-		//			for _, v := range res {
-		//				message += fmt.Sprintf("\t%s\t%d\t%d\t%s\n", v.Name, v.CurrentEpisode, len(v.Members), v.LastModified.Format("Mon, January 02"))
-		//			}
-
-		//Outputs list to chat in codeblock form
-		//			chat.SendMessageToChannel(m.ChannelID, "```"+message+"```")
-		//		}
 	case "start":
 		{
 			//Sends error to user if there are insufficient arguments

--- a/handlers/anime.go
+++ b/handlers/anime.go
@@ -288,7 +288,6 @@ func JunbiOK(m *discordgo.MessageCreate, args []string) error {
 	//Read values from the Redis database, creates key on per-chat basis
 	key := makeKey("junbistatus:%s", m.ChannelID)
 	res := junbiStatus{true, args}
-	deserialize(conn, key, &res)
 
 	chat.SendMessageToChannel(m.ChannelID, fmt.Sprintf("Junbi OK? Type !rdy to confirm!"))
 

--- a/handlers/anime.go
+++ b/handlers/anime.go
@@ -9,12 +9,21 @@ import (
 	"github.com/bwmarrin/discordgo"
 )
 
+//Defines types used in AnimeStatus
 type animeStatus struct {
 	Name           string
 	CurrentEpisode int64
+	Members        []string
 	LastModified   time.Time
 }
 
+//Defines types used in JunbiOK and JunbiRdy
+type junbiStatus struct {
+	Initialized bool
+	Members     []string
+}
+
+//Constrains passed value to specified range
 func clamp(v, l, h int64) int64 {
 	if v < l {
 		return l
@@ -28,158 +37,317 @@ func clamp(v, l, h int64) int64 {
 }
 
 func AnimeStatus(m *discordgo.MessageCreate, args []string) error {
+	//Message user with list of commands if no command is specified
 	if len(args) < 2 {
-		chat.SendPrivateMessageTo(m.Author.ID, "Usage: !anime <del|mv|incr|decr|set|list|get|start> <name> [<value>]")
+		chat.SendPrivateMessageTo(m.Author.ID, "Usage: !anime <add|drop|del|incr|decr|set|rename|get|list|start> <name> [<value>]")
 	}
 
+	//Open connection to Redis server
 	conn := Redis.Get()
 	defer conn.Close()
 
-	key := makeKey("animestatus:%s", m.Author.ID)
+	//Read values from the Redis database, creates key on per-chat basis
+	key := makeKey("animestatus:%s", m.ChannelID)
 	res := map[string]animeStatus{}
 	deserialize(conn, key, &res)
 
-	// Supports del, mv, incr, decr, set, list, start
+	// Supports add, drop, del, incr, decr, set, rename, get, list, start
 	switch args[0] {
+	case "add":
+		{
+			//Sends error to user if there are insufficient arguments
+			if len(args) != 2 {
+				chat.SendPrivateMessageTo(m.Author.ID, "Usage: !anime add <name>")
+				return nil
+			}
+
+			//Checks to see if specified anime exists, adds new entry if it does not
+			v, ok := res[args[1]]
+			if !ok {
+				res[args[1]] = animeStatus{args[1], 0, []string{m.Author.ID}, time.Now()}
+			} else {
+				//Checks to see if the user has already added this anime
+				for _, n := range v.Members {
+					if n == m.Author.ID {
+						chat.SendPrivateMessageTo(m.Author.ID, fmt.Sprintf("You have already added %s.", args[1]))
+						return nil
+					}
+				}
+				//Adds user to Members
+				v.Members = append(v.Members, m.Message.ID)
+				res[args[1]] = v
+			}
+		}
+	case "drop":
+		{
+			//Sends error to user if there are insufficient arguments
+			if len(args) != 2 {
+				chat.SendPrivateMessageTo(m.Author.ID, "Usage: !anime drop <name>")
+				return nil
+			}
+
+			//Checks to see if specified anime exists, aborts if it does not
+			v, ok := res[args[1]]
+			if !ok {
+				chat.SendPrivateMessageTo(m.Author.ID, fmt.Sprintf("%s doesn't exist, type '!anime list' for a list of shows.", args[1]))
+				return nil
+			}
+
+			//Removes user from AnimeStatus.Members of specified anime
+			i := 0
+			for _, n := range v.Members {
+				if n != m.Author.ID {
+					v.Members[i] = n
+					i++
+				}
+			}
+			v.Members = v.Members[:i]
+			res[args[1]] = v
+
+			//Deletes anime if zero members are present after drop
+			if len(v.Members) == 0 {
+				delete(res, args[1])
+			}
+		}
 	case "del":
 		{
+			//Sends error to user if there are insufficient arguments
 			if len(args) != 2 {
 				chat.SendPrivateMessageTo(m.Author.ID, "Usage: !anime del <name>")
 				return nil
 			}
 
+			//Deletes specified anime, regardless of members
 			delete(res, args[1])
-			break
 		}
-	case "mv":
+	case "rename":
 		{
+			//Sends error to user if there are insufficient arguments
 			if len(args) != 3 {
-				chat.SendPrivateMessageTo(m.Author.ID, "Usage: !anime mv <name> <new>")
+				chat.SendPrivateMessageTo(m.Author.ID, "Usage: !anime rename <name> <new>")
 				return nil
 			}
 
-			_, ok := res[args[2]]
-			v, ok2 := res[args[1]]
+			v, ok := res[args[1]]
+			_, ok2 := res[args[2]]
 
-			if ok || !ok2 {
-				chat.SendPrivateMessageTo(m.Author.ID, "!anime mv cannot overwrite elements, or source element did not exist")
+			//Checks to see if specified anime exists, aborts if it does not
+			if !ok {
+				chat.SendPrivateMessageTo(m.Author.ID, fmt.Sprintf("%s doesn't exist, type '!anime list' for a list of shows.", args[1]))
+				return nil
 			}
 
+			//Checks to see if new desired name exists, aborts if it does
+			if ok2 {
+				chat.SendPrivateMessageTo(m.Author.ID, fmt.Sprintf("%s is already in use, type '!anime list' for a list of shows.", args[2]))
+				return nil
+			}
+
+			//Changes AnimeStatus.Name of the source element and copies it to the specified target element
 			v.Name = args[2]
 			res[args[2]] = v
+			//Deletes inintial element after copy
 			delete(res, args[1])
-			break
-		}
-	case "set":
-		{
-			if len(args) != 3 {
-				chat.SendPrivateMessageTo(m.Author.ID, "Usage: !anime set <name> <ep#>")
-				return nil
-			}
-
-			episode, err := strconv.ParseInt(args[2], 10, 64)
-			if err != nil {
-				return err
-			}
-
-			episode = clamp(episode, -10, 1000)
-			v, ok := res[args[1]]
-			if !ok {
-				res[args[1]] = animeStatus{args[1], episode, time.Now()}
-			} else {
-				v.CurrentEpisode = episode
-				v.LastModified = time.Now()
-				res[args[1]] = v
-			}
-
-			v = res[args[1]]
-			chat.SendMessageToChannel(m.ChannelID, fmt.Sprintf("%s - %d (%s)", v.Name, v.CurrentEpisode, v.LastModified.Format("Mon, January 02")))
-			break
-		}
-	case "get":
-		{
-			if len(args) != 2 {
-				chat.SendPrivateMessageTo(m.Author.ID, "Usage: !anime get <name>")
-				return nil
-			}
-
-			v, ok := res[args[1]]
-			if !ok {
-				chat.SendMessageToChannel(m.ChannelID, fmt.Sprintf("%s doesn't exist, try list", args[1]))
-				return nil
-			}
-			chat.SendMessageToChannel(m.ChannelID, fmt.Sprintf("%s - %d (%s)", v.Name, v.CurrentEpisode, v.LastModified.Format("Mon, January 02")))
 		}
 	case "incr", "decr":
 		{
+			//Sends error to user if there are insufficient arguments
 			if len(args) != 2 {
 				chat.SendPrivateMessageTo(m.Author.ID, fmt.Sprintf("Usage: !anime %s <name>", args[0]))
 				return nil
 			}
 
+			//Sets delta to -1 for decr, 1 for incr
 			delta := int64(-1)
 			if args[0] == "incr" {
 				delta = 1
 			}
 
+			//Checks to see if specified anime exists, aborts if it does not
 			v, ok := res[args[1]]
 			if !ok {
-				chat.SendPrivateMessageTo(m.Author.ID, fmt.Sprintf("Usage: !anime %s <name> requires a valid name", args[0]))
+				chat.SendPrivateMessageTo(m.Author.ID, fmt.Sprintf("%s doesn't exist, type '!anime list' for a list of shows.", args[1]))
 				return nil
-			} else {
-				v.CurrentEpisode = v.CurrentEpisode + delta
-				v.CurrentEpisode = clamp(v.CurrentEpisode, -10, 1000)
-
-				if args[0] == "incr" {
-					v.LastModified = time.Now()
-				}
-
-				res[args[1]] = v
-				chat.SendMessageToChannel(m.ChannelID, fmt.Sprintf("%s - %d (%s)", v.Name, v.CurrentEpisode, v.LastModified.Format("Mon, January 02")))
 			}
+
+			//Modifies episode count by delta, updates time if incr is called
+			v.CurrentEpisode = v.CurrentEpisode + delta
+			v.CurrentEpisode = clamp(v.CurrentEpisode, -10, 1000)
+
+			if args[0] == "incr" {
+				v.LastModified = time.Now()
+			}
+
+			//Updates res then sends the new value to chat
+			res[args[1]] = v
+			chat.SendMessageToChannel(m.ChannelID, fmt.Sprintf("%s - %d (%s)", v.Name, v.CurrentEpisode, v.LastModified.Format("Mon, January 02")))
+		}
+	case "set":
+		{
+			//Sends error to user if there are insufficient arguments
+			if len(args) != 3 {
+				chat.SendPrivateMessageTo(m.Author.ID, "Usage: !anime set <name> <ep#>")
+				return nil
+			}
+
+			//Converts arg to int, aborts if err, clamps converted value to specified range
+			episode, err := strconv.ParseInt(args[2], 10, 64)
+			if err != nil {
+				return err
+			}
+			episode = clamp(episode, -10, 1000)
+
+			//Checks to see if specified anime exists, aborts if it does not
+			v, ok := res[args[1]]
+			if !ok {
+				chat.SendPrivateMessageTo(m.Author.ID, fmt.Sprintf("%s doesn't exist, type '!anime list' for a list of shows.", args[1]))
+				return nil
+			}
+			//Updates CurrentEpisode and LastModified
+			v.CurrentEpisode = episode
+			v.LastModified = time.Now()
+
+			//Updates res then sends the new value to chat
+			res[args[1]] = v
+			chat.SendMessageToChannel(m.ChannelID, fmt.Sprintf("%s - %d (%s)", v.Name, v.CurrentEpisode, v.LastModified.Format("Mon, January 02")))
+		}
+	case "get":
+		{
+			//Sends error to user if there are insufficient arguments
+			if len(args) != 2 {
+				chat.SendPrivateMessageTo(m.Author.ID, "Usage: !anime get <name>")
+				return nil
+			}
+
+			//Checks to see if specified anime exists, aborts if it does not
+			v, ok := res[args[1]]
+			if !ok {
+				chat.SendPrivateMessageTo(m.Author.ID, fmt.Sprintf("%s doesn't exist, type '!anime list' for a list of shows.", args[1]))
+				return nil
+			}
+			//Builds message
+			message := "\tName\tLast Ep\tMembers\tLast Watched\n"
+			message += fmt.Sprintf("\t%s\t%d\t%d\t%s\n", v.Name, v.CurrentEpisode, len(v.Members), v.LastModified.Format("Mon, January 02"))
+			message += fmt.Sprintf("Participants:\t")
+			for _, n := range v.Members {
+				message += fmt.Sprintf("%s\t", n)
+			}
+			message += fmt.Sprintf("\n")
+
+			//Outputs message to chat in codeblock form
+			chat.SendMessageToChannel(m.ChannelID, "```"+message+"```")
 		}
 	case "list":
 		{
-			message := ""
+			//Builds list of existing anime
+			message := "\tName\tLast Ep\tMembers\tLast Watched\n"
 			for _, v := range res {
-				message += fmt.Sprintf("\t%s\t%d\t%s\n", v.Name, v.CurrentEpisode, v.LastModified.Format("Mon, January 02"))
+				message += fmt.Sprintf("\t%s\t%d\t%d\t%s\n", v.Name, v.CurrentEpisode, len(v.Members), v.LastModified.Format("Mon, January 02"))
 			}
 
+			//Outputs list to chat in codeblock form
 			chat.SendMessageToChannel(m.ChannelID, "```"+message+"```")
 		}
 	case "start":
 		{
+			//Sends error to user if there are insufficient arguments
 			if len(args) != 2 {
-				chat.SendPrivateMessageTo(m.Author.ID, fmt.Sprintf("Usage: !anime %s <name>", args[0]))
+				chat.SendPrivateMessageTo(m.Author.ID, "Usage: !anime start <name>")
 				return nil
 			}
 
-			delta := int64(1)
+			//Checks to see if specified anime exists, aborts if it does not
 			v, ok := res[args[1]]
-
 			if !ok {
-				chat.SendPrivateMessageTo(m.Author.ID, fmt.Sprintf("Usage: !anime %s <name> requires a valid name", args[0]))
+				chat.SendPrivateMessageTo(m.Author.ID, fmt.Sprintf("%s doesn't exist, type '!anime list' for a list of shows.", args[1]))
 				return nil
-			} else {
-				v.CurrentEpisode = v.CurrentEpisode + delta
-				v.CurrentEpisode = clamp(v.CurrentEpisode, -10, 1000)
-				v.LastModified = time.Now()
-				res[args[1]] = v
-				chat.SendMessageToChannel(m.ChannelID, fmt.Sprintf("Starting %s episode %d.", v.Name, v.CurrentEpisode))
-				time.Sleep(300 * time.Millisecond)
-				JunbiOK(m, []string{"3"})
 			}
+			//Increments episode and sets time to now
+			v.CurrentEpisode++
+			v.CurrentEpisode = clamp(v.CurrentEpisode, -10, 1000)
+			v.LastModified = time.Now()
+			//Updates res then sends the value to chat
+			res[args[1]] = v
+			chat.SendMessageToChannel(m.ChannelID, fmt.Sprintf("Starting %s episode %d.", v.Name, v.CurrentEpisode))
+			//Sleeps then calls JunbiOK
+			time.Sleep(300 * time.Millisecond)
+			JunbiOK(m, v.Members)
 		}
 	}
-
+	//Write the modified value to the Redis database
 	serialize(conn, key, &res)
 	return nil
 }
 
+//Initializes the values for JunbiRdy (!rdy), sends ready message to channel
+func JunbiOK(m *discordgo.MessageCreate, args []string) error {
+	//Open connection to Redis server
+	conn := Redis.Get()
+	defer conn.Close()
+
+	//Read values from the Redis database, creates key on per-chat basis
+	key := makeKey("junbistatus:%s", m.ChannelID)
+	res := junbiStatus{true, args}
+	deserialize(conn, key, &res)
+
+	chat.SendMessageToChannel(m.ChannelID, fmt.Sprintf("Junbi OK? Type !rdy to confirm!"))
+
+	//Write the modified value to the Redis database
+	serialize(conn, key, &res)
+	return nil
+}
+
+func JunbiRdy(m *discordgo.MessageCreate, args []string) error {
+	//Open connection to Redis server
+	conn := Redis.Get()
+	defer conn.Close()
+
+	//Read values from the Redis database, creates key on per-chat basis
+	key := makeKey("junbistatus:%s", m.ChannelID)
+	res := junbiStatus{}
+	deserialize(conn, key, &res)
+
+	//Aborts the function if !anime start hasn't been called
+	if res.Initialized != true {
+		chat.SendMessageToChannel(m.ChannelID, fmt.Sprintf("No anime initiated. Type !anime start <name> to begin!"))
+		return nil
+	}
+
+	//Removes user from junbiStatus.Members
+	i := 0
+	for _, n := range res.Members {
+		if n != m.Author.ID {
+			res.Members[i] = n
+			i++
+		}
+	}
+	res.Members = res.Members[:i]
+
+	//Displays the remaining members that haven't confirmed with !rdy
+	if len(res.Members) != 0 {
+		message := fmt.Sprintf("Waiting on:\t")
+		for _, n := range res.Members {
+			message += fmt.Sprintf("%s\t", n)
+		}
+		chat.SendMessageToChannel(m.ChannelID, message)
+		return nil
+	}
+
+	//Resets Initialized flag to false, starts countdown
+	res.Initialized = false
+	Countdown(m, []string{"3"})
+
+	//Write the modified value to the Redis database
+	serialize(conn, key, &res)
+	return nil
+}
+
+//Simple countdown function
 func Countdown(m *discordgo.MessageCreate, args []string) error {
 	start := int64(3)
 	var err error
 
+	//Sets countdown length to user input, with a fallback value of 3
 	if len(args) == 1 {
 		start, err = strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
@@ -187,56 +355,17 @@ func Countdown(m *discordgo.MessageCreate, args []string) error {
 		}
 	}
 
+	//Constricts countdown length to 30 seconds
 	if start > 30 {
 		start = 30
 	}
 
+	//Starts the countdown
 	for i := int64(0); i < start; i++ {
 		chat.SendMessageToChannel(m.ChannelID, fmt.Sprintf("%d", start-i))
 		time.Sleep(time.Second)
 	}
 
 	chat.SendMessageToChannel(m.ChannelID, "g")
-	return nil
-}
-
-var (
-	junbiCount, junbiMembers int64
-	junbiInitiated           bool
-)
-
-func JunbiOK(m *discordgo.MessageCreate, args []string) error {
-	var err error
-	junbiCount = 1
-	junbiMembers = 3
-	junbiInitiated = true
-
-	if len(args) == 1 {
-		junbiMembers, err = strconv.ParseInt(args[0], 10, 64)
-		if err != nil {
-			junbiMembers = 3
-		}
-	}
-
-	chat.SendMessageToChannel(m.ChannelID, fmt.Sprintf("Junbi OK? Type !rdy to confirm!"))
-	return nil
-}
-
-func JunbiRdy(m *discordgo.MessageCreate, args []string) error {
-	if junbiInitiated != true {
-		chat.SendMessageToChannel(m.ChannelID, fmt.Sprintf("Countdown has not been initiated! Type !junbiok to begin!"))
-		return nil
-	} else {
-		junbiCount++
-	}
-
-	if junbiCount < junbiMembers {
-		count := int64(junbiMembers - junbiCount)
-		chat.SendMessageToChannel(m.ChannelID, fmt.Sprintf("Waiting on %d more!", count))
-		return nil
-	} else {
-		Countdown(m, []string{"3"})
-		junbiInitiated = false
-	}
 	return nil
 }

--- a/handlers/anime.go
+++ b/handlers/anime.go
@@ -202,11 +202,14 @@ func Countdown(m *discordgo.MessageCreate, args []string) error {
 
 var (
 	junbiCount, junbiMembers int64
+	junbiInitiated           bool
 )
 
 func JunbiOK(m *discordgo.MessageCreate, args []string) error {
-	junbiMembers = 3
 	var err error
+	junbiCount = 1
+	junbiMembers = 3
+	junbiInitiated = true
 
 	if len(args) == 1 {
 		junbiMembers, err = strconv.ParseInt(args[0], 10, 64)
@@ -215,20 +218,27 @@ func JunbiOK(m *discordgo.MessageCreate, args []string) error {
 		}
 	}
 
-	if junbiCount == 0 {
-		chat.SendMessageToChannel(m.ChannelID, fmt.Sprintf("Junbi OK? Type !rdy to confirm!"))
-		junbiCount++
+	chat.SendMessageToChannel(m.ChannelID, fmt.Sprintf("Junbi OK? Type !rdy to confirm!"))
+	return nil
+}
+
+func JunbiRdy(m *discordgo.MessageCreate, args []string) error {
+	var err error
+
+	if junbiInitiated != true {
+		chat.SendMessageToChannel(m.ChannelID, fmt.Sprintf("Countdown has not been initiated! Type !junbiok to begin!"))
 		return nil
+	} else {
+		junbiCount++
 	}
 
 	if junbiCount < junbiMembers {
 		count := int64(junbiMembers - junbiCount)
 		chat.SendMessageToChannel(m.ChannelID, fmt.Sprintf("Waiting on %d more!", count))
-		junbiCount++
 		return nil
 	} else {
 		Countdown(m, []string{"3"})
-		junbiCount = 0
+		junbiInitiated = false
 	}
 	return nil
 }

--- a/handlers/anime.go
+++ b/handlers/anime.go
@@ -167,7 +167,7 @@ func AnimeStatus(m *discordgo.MessageCreate, args []string) error {
 				res[args[1]] = v
 				chat.SendMessageToChannel(m.ChannelID, fmt.Sprintf("Starting %s episode %d.", v.Name, v.CurrentEpisode))
 				time.Sleep(300 * time.Millisecond)
-				junbiCount(m, []string{"3"})
+				JunbiOK(m, []string{"3"})
 			}
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -105,7 +105,7 @@ func main() {
 	mapping["countdown"] = handlers.Countdown
 	mapping["anime"] = handlers.AnimeStatus
 	mapping["junbiok"] = handlers.JunbiOK
-	mapping["rdy"] = handlers.JunbiOK
+	mapping["rdy"] = handlers.JunbiRdy
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/searchresult", handlers.SearchResults)

--- a/main.go
+++ b/main.go
@@ -104,7 +104,6 @@ func main() {
 	mapping["search-help"] = handlers.SearchHelp
 	mapping["countdown"] = handlers.Countdown
 	mapping["anime"] = handlers.AnimeStatus
-	mapping["junbiok"] = handlers.JunbiOK
 	mapping["rdy"] = handlers.JunbiRdy
 
 	mux := http.NewServeMux()

--- a/main.go
+++ b/main.go
@@ -104,7 +104,7 @@ func main() {
 	mapping["search-help"] = handlers.SearchHelp
 	mapping["countdown"] = handlers.Countdown
 	mapping["anime"] = handlers.AnimeStatus
-	mapping["junbiOK"] = handlers.JunbiOK
+	mapping["junbiok"] = handlers.JunbiOK
 	mapping["rdy"] = handlers.JunbiOK
 
 	mux := http.NewServeMux()


### PR DESCRIPTION
**Change Overview**
- Adding comments to code.
- Cleaning up indent error flow.
- Reordering items for readability.
- Changing key creation to a per-chat basis rather than per-author basis, so all users can interact with the anime list. 
- Adding Members field to animeStatus struct.
- Adding "add," "drop," and "start" functionality to AnimeStatus function.
- Moving "set" create behavior to "add."
- Renaming "mv" to "rename" to clarify its intended purpose.
- Splitting JunbiOK function into JunbiOK and JunbiRdy.
- Rewriting JunbiOK/JunbiRdy for more robust behavior.
- Removing global variables required by JunbiOK, replace them with Redis keystores.
- Removed !junbiok from list of callable handlers.

**Members**
The animeStatus struct now includes a field to contain participant usernames. The usernames are stored in a map, where the Author's ID is used for the key and the Author's Username is used for the paired value. This allows the various functions that reference this container to display the human-readable usernames, without functionality breaking if the user changes their username.

**!anime add**
Takes the place of "set" for initializing a new anime. Allows users to add themselves to an existing anime which drives the "start," "JunbiOK," and "JunbiRdy" behavior. 

**!anime drop**
Allows the user to remove themselves from an added anime, deleting the anime if no users remain after the drop.

**!anime start**
Replaces the previous !junbiOK / !rdy functionality for initiating a confirmation enabled countdown. Calling !anime start automatically increments the called series, displays the episode that the user is currently on (whereas !anime list or get shows the last episode watched), then calls JunbiOK to start the confirmation countdown.

**!anime get / list**
Calling !anime list now includes a field for the number of members associated with a particular anime. Calling !anime get now includes a list of all the associated members' usernames.

**JunbiOK / JunbiRdy**
Now checks to see if an anime has been queued for start before enabling !rdy. Calling !rdy now references the m.Author.ID rather than simply incrementing a counter and displays usernames remaining rather than number remaining. When initiating a !anime start, the members associated with that series are passed to JunbiOK. Each !rdy call removes the user from the list of remaining members, displaying the remaining usernames of the users who have yet to confirm with !rdy. Once all members have confirmed, a countdown is started and the flag for a countdown is reset. 
